### PR TITLE
Display Getting Garbled After Sometime

### DIFF
--- a/firmware/Adafruit_MCP23008.cpp
+++ b/firmware/Adafruit_MCP23008.cpp
@@ -24,32 +24,32 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   //Wire.setSpeed(CLOCK_SPEED_100KHZ);
   //Wire.stretchClock(true);
   Wire.begin();
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   // set defaults!
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)MCP23008_IODIR);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0xFF);  // all inputs
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)0x00);	
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.endTransmission();
   delayMicroseconds(5);
 }
@@ -139,13 +139,13 @@ uint8_t Adafruit_MCP23008::digitalRead(uint8_t p) {
 
 uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)addr);	
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.endTransmission();
   delayMicroseconds(5);
   Wire.requestFrom(MCP23008_ADDRESS | i2caddr, 1);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   
   return Wire.read();
 }
@@ -153,11 +153,11 @@ uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
 
 void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)addr);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.write((byte)data);
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.endTransmission();
   delayMicroseconds(5);
 }

--- a/firmware/Adafruit_MCP23008.cpp
+++ b/firmware/Adafruit_MCP23008.cpp
@@ -21,8 +21,8 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   }
   i2caddr = addr;
 
-  Wire.setSpeed(CLOCK_SPEED_100KHZ);
-  Wire.stretchClock(true);
+  //Wire.setSpeed(CLOCK_SPEED_100KHZ);
+  //Wire.stretchClock(true);
   Wire.begin();
   delayMicroseconds(2);
   // set defaults!
@@ -51,7 +51,7 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   Wire.write((byte)0x00);	
   delayMicroseconds(2);
   Wire.endTransmission();
-  delayMicroseconds(2);
+  delayMicroseconds(5);
 }
 
 void Adafruit_MCP23008::begin(void) {
@@ -143,7 +143,7 @@ uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
   Wire.write((byte)addr);	
   delayMicroseconds(2);
   Wire.endTransmission();
-  delayMicroseconds(2);
+  delayMicroseconds(5);
   Wire.requestFrom(MCP23008_ADDRESS | i2caddr, 1);
   delayMicroseconds(2);
   
@@ -159,5 +159,5 @@ void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
   Wire.write((byte)data);
   delayMicroseconds(2);
   Wire.endTransmission();
-  delayMicroseconds(2);
+  delayMicroseconds(5);
 }

--- a/firmware/Adafruit_MCP23008.cpp
+++ b/firmware/Adafruit_MCP23008.cpp
@@ -21,37 +21,35 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   }
   i2caddr = addr;
 
-  //Wire.setSpeed(CLOCK_SPEED_100KHZ);
-  //Wire.stretchClock(true);
   Wire.begin();
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   // set defaults!
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)MCP23008_IODIR);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0xFF);  // all inputs
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)0x00);	
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.endTransmission();
-  delayMicroseconds(5);
+  delayMicroseconds(40);
 }
 
 void Adafruit_MCP23008::begin(void) {
@@ -139,13 +137,13 @@ uint8_t Adafruit_MCP23008::digitalRead(uint8_t p) {
 
 uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)addr);	
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.endTransmission();
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.requestFrom(MCP23008_ADDRESS | i2caddr, 1);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   
   return Wire.read();
 }
@@ -153,11 +151,11 @@ uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
 
 void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)addr);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.write((byte)data);
-  delayMicroseconds(5);
+  delayMicroseconds(40);
   Wire.endTransmission();
-  delayMicroseconds(5);
+  delayMicroseconds(40);
 }

--- a/firmware/Adafruit_MCP23008.cpp
+++ b/firmware/Adafruit_MCP23008.cpp
@@ -21,6 +21,8 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   }
   i2caddr = addr;
 
+  Wire.setSpeed(CLOCK_SPEED_100KHZ);
+  Wire.stretchClock(true);
   Wire.begin();
   delayMicroseconds(2);
   // set defaults!

--- a/firmware/Adafruit_MCP23008.cpp
+++ b/firmware/Adafruit_MCP23008.cpp
@@ -22,22 +22,34 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   i2caddr = addr;
 
   Wire.begin();
-
+  delayMicroseconds(2);
   // set defaults!
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  delayMicroseconds(2);
   Wire.write((byte)MCP23008_IODIR);
+  delayMicroseconds(2);
   Wire.write((byte)0xFF);  // all inputs
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);
+  delayMicroseconds(2);
   Wire.write((byte)0x00);	
+  delayMicroseconds(2);
   Wire.endTransmission();
-
+  delayMicroseconds(2);
 }
 
 void Adafruit_MCP23008::begin(void) {
@@ -125,17 +137,25 @@ uint8_t Adafruit_MCP23008::digitalRead(uint8_t p) {
 
 uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  delayMicroseconds(2);
   Wire.write((byte)addr);	
+  delayMicroseconds(2);
   Wire.endTransmission();
+  delayMicroseconds(2);
   Wire.requestFrom(MCP23008_ADDRESS | i2caddr, 1);
-
+  delayMicroseconds(2);
+  
   return Wire.read();
 }
 
 
 void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  delayMicroseconds(2);
   Wire.write((byte)addr);
+  delayMicroseconds(2);
   Wire.write((byte)data);
+  delayMicroseconds(2);
   Wire.endTransmission();
+  delayMicroseconds(2);
 }


### PR DESCRIPTION
Thank you for creating this fork. I've been using it for a project and it worked great out of the box. However, after running it for a while, the LCD screen gets corrupted with garbled characters. I solved the issue by adding extra delays of 40 microseconds after each `Wire` command. The LCD is now stable. To further test it, I run it overnight without any problem.

My Spark Core was connected to the [LCD screen](https://www.adafruit.com/products/399) via Adafruit's [backpack](https://www.adafruit.com/products/292) and [level converter](https://www.adafruit.com/products/757).

I thought to share my code with you for people who may have the same problem as I did.
