### PR TITLE
Fixed typos in example filenames

### DIFF
--- a/firmware/examples/LiquidCrystal_i2c.ino
+++ b/firmware/examples/LiquidCrystal_i2c.ino
@@ -1,15 +1,16 @@
 /***************************************************
-  A fork of Adafruit LiquidCrystal library that support 
+  A fork of Adafruit LiquidCrystal library that support
   i2c / SPI character LCD backpack.
  ****************************************************/
 
 #include "Adafruit_LiquidCrystal/Adafruit_LiquidCrystal.h"
 
-// TO connect via SPI. Data pin is A5, Clock is A3 and Latch is A2
-LiquidCrystal lcd(A5, A3, A2);
+// TO connect via I2C. Data pin is D0, Clock is D1
+// By default, no jumpers are soldered, giving an address of 0.
+LiquidCrystal lcd(0);
 
 void setup() {
-  // set up the LCD's number of rows and columns: 
+  // set up the LCD's number of rows and columns:
   lcd.begin(20, 4);
   // Print a message to the LCD.
   lcd.print("hello, world!");

--- a/firmware/examples/LiquidCrystal_spi.ino
+++ b/firmware/examples/LiquidCrystal_spi.ino
@@ -5,9 +5,8 @@
 
 #include "Adafruit_LiquidCrystal/Adafruit_LiquidCrystal.h"
 
-// TO Connect via I2C. Data pin is D0, Clock is D1
-// By default, no jumpers are soldered, giving an address of 0.
-LiquidCrystal lcd(0);
+// TO connect via SPI. Data pin is A5, Clock is A3 and Latch is A2
+LiquidCrystal lcd(A5, A3, A2);
 
 void setup() {
   // set up the LCD's number of rows and columns: 


### PR DESCRIPTION
Example files were named incorrectly, where I2C example was named as SPI, and SPI example was named as I2C.
